### PR TITLE
change movement to use left switch joystick

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -31,10 +31,10 @@ bool input_init(void)
 	
 	// default mappings
 #ifdef __SWITCH__
-	mappings[LEFTKEY].jbut        = 12;
-	mappings[UPKEY].jbut          = 13;
-	mappings[RIGHTKEY].jbut       = 14;
-	mappings[DOWNKEY].jbut        = 15;
+	mappings[LEFTKEY].jbut        = 16;
+	mappings[UPKEY].jbut          = 17;
+	mappings[RIGHTKEY].jbut       = 18;
+	mappings[DOWNKEY].jbut        = 19;
 
 	mappings[FIREKEY].jbut        = 0;  // A
 	mappings[JUMPKEY].jbut        = 1;  // B


### PR DESCRIPTION
This changes the direction controls to the left analog stick. See this gist I wrote that explains the numbers for joystick input. https://gist.github.com/minkcv/ccb04c62c287f6bf7c01fcb3d2014474

If you want to leave the direction controls to the buttons that is fine but please tell me how to build the nro for the switch so I can do my own build that has uses the left analog stick. 